### PR TITLE
Avoid using dot notation to allow complex keys

### DIFF
--- a/lib/carto/tree/filterset.js
+++ b/lib/carto/tree/filterset.js
@@ -92,7 +92,7 @@ tree.Filterset.prototype.toJS = function(env) {
       val = filter._val.toString(true);
     }
     var attrs = "data";
-    return attrs + "." + filter.key.value  + " " + op + " " + (val.is === 'string' ? "'" + val.toString().replace(/'/g, "\\'") + "'" : val);
+    return attrs + "['" + filter.key.value  + "'] " + op + " " + (val.is === 'string' ? "'" + val.toString().replace(/'/g, "\\'") + "'" : val);
   }).join(' && ');
 };
 


### PR DESCRIPTION
So for instance it's possible to use `mapnik::geometry_type`.

cc @javisantana 