### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carto",
-  "version": "0.15.1-cdb3",
+  "version": "0.15.1-cdb4",
   "description": "CartoCSS Stylesheet Compiler",
   "url": "https://github.com/cartodb/carto",
   "repository": {


### PR DESCRIPTION
To avoid problems with npm-shrinkwrap we have to update the version.