### PR TITLE
Use hexadecimal values instead octal

### DIFF
--- a/lib/carto/index.js
+++ b/lib/carto/index.js
@@ -53,7 +53,7 @@ var carto = {
         if (typeof(extract[2]) === 'string') {
             error.push(stylize((ctx.line + 1) + ' ' + extract[2], 'grey'));
         }
-        error = options.indent + error.join('\n' + options.indent) + '\033[0m\n';
+        error = options.indent + error.join('\n' + options.indent) + '\x1B[0m\n';
 
         message = options.indent + message + stylize(ctx.message, 'red');
         if (ctx.filename) (message += stylize(' in ', 'red') + ctx.filename);
@@ -111,6 +111,6 @@ function stylize(str, style) {
         'red' : [31, 39],
         'grey' : [90, 39]
     };
-    return '\033[' + styles[style][0] + 'm' + str +
-           '\033[' + styles[style][1] + 'm';
+    return '\x1B[' + styles[style][0] + 'm' + str +
+           '\x1B[' + styles[style][1] + 'm';
 }


### PR DESCRIPTION
Strict mode in ECMAScript 5 forbids octal syntax. 

This octal literals are breaking the webpack compilation in upper packages like tangram-cartocss.

Mapbox have already [fixed this](https://github.com/mapbox/carto/blob/master/lib/carto/index.js#L104)

This PR changes the octal literals and uses hexadecimal ones.