### PR TITLE
Expose filtered field

### DIFF
--- a/lib/carto/renderer_js.js
+++ b/lib/carto/renderer_js.js
@@ -229,6 +229,8 @@ CartoCSS.prototype = {
           // serach the max index to know rendering order
           lyr.index = _.max(props[v].map(function(a) { return a.index; }).concat(lyr.index));
           lyr.constant = !_.any(props[v].map(function(a) { return !a.constant; }));
+          // True when the property is filtered.
+          lyr.filtered = props[v][0].filtered;
         }
       }
 

--- a/lib/carto/tree/definition.js
+++ b/lib/carto/tree/definition.js
@@ -236,7 +236,11 @@ tree.Definition.prototype.toJS = function(env) {
         }
 
         r.constant = rule.value.ev(env).is !== 'field';
-        r.filtered = !!_if;
+        var DEFAULT_FILTER = "(8388607 & (1 << ctx.zoom))";
+        r.filtered = false;
+        if (_if && _if !== DEFAULT_FILTER){
+            r.filtered = true;
+        }
 
         shaderAttrs[rule.name].push(r);
       } else {

--- a/lib/carto/tree/definition.js
+++ b/lib/carto/tree/definition.js
@@ -216,10 +216,19 @@ tree.Definition.prototype.toJS = function(env) {
   var zoom = "(" + this.zoom + " & (1 << ctx.zoom))";
   var frame_offset = this.frame_offset;
   var _if = this.filters.toJS(env);
+  var filtered = _if !== '';
   var filters = [zoom];
-  if(_if) filters.push(_if);
-  if(frame_offset) filters.push('ctx["frame-offset"] === ' + frame_offset);
+
+  if(_if) {
+      filters.push(_if);
+  }
+
+  if(frame_offset){
+   filters.push('ctx["frame-offset"] === ' + frame_offset);
+  }
+
   _if = filters.join(" && ");
+  
   _.each(this.rules, function(rule) {
       if(rule instanceof tree.Rule) {
         shaderAttrs[rule.name] = shaderAttrs[rule.name] || [];
@@ -230,30 +239,16 @@ tree.Definition.prototype.toJS = function(env) {
         };
 
         if (_if) {
-          r.js = "if(" + _if + "){" + rule.value.toJS(env) + "}"
+          r.js = "if(" + _if + "){" + rule.value.toJS(env) + "}";
         } else {
           r.js = rule.value.toJS(env);
         }
 
         r.constant = rule.value.ev(env).is !== 'field';
-        var DEFAULT_FILTER = "(8388607 & (1 << ctx.zoom))";
-        r.filtered = false;
-        if (_if && _if !== DEFAULT_FILTER){
-            r.filtered = true;
-        }
-
+        r.filtered = filtered;
         shaderAttrs[rule.name].push(r);
       } else {
         throw new Error("Ruleset not supported");
-        //if (rule instanceof tree.Ruleset) {
-          //var sh = rule.toJS(env);
-          //for(var v in sh) {
-            //shaderAttrs[v] = shaderAttrs[v] || [];
-            //for(var attr in sh[v]) {
-              //shaderAttrs[v].push(sh[v][attr]);
-            //}
-          //}
-        //}
       }
   });
   return shaderAttrs;

--- a/lib/carto/tree/definition.js
+++ b/lib/carto/tree/definition.js
@@ -210,47 +210,37 @@ tree.Definition.prototype.toXML = function(env, existing) {
 
 tree.Definition.prototype.toJS = function(env) {
   var shaderAttrs = {};
-
-  // merge conditions from filters with zoom condition of the
-  // definition
-  var zoom = "(" + this.zoom + " & (1 << ctx.zoom))";
   var frame_offset = this.frame_offset;
-  var _if = this.filters.toJS(env);
-  var filtered = _if !== '';
-  var filters = [zoom];
+  var zoomFilter = "(" + this.zoom + " & (1 << ctx.zoom))";
+  var filters = [zoomFilter];
+  var originalFilters = this.filters.toJS(env);
 
-  if(_if) {
-      filters.push(_if);
-  }
-
-  if(frame_offset){
-   filters.push('ctx["frame-offset"] === ' + frame_offset);
-  }
-
-  _if = filters.join(" && ");
   
-  _.each(this.rules, function(rule) {
-      if(rule instanceof tree.Rule) {
-        shaderAttrs[rule.name] = shaderAttrs[rule.name] || [];
+  if (originalFilters) {
+      filters.push(originalFilters);
+  }
 
-        var r = {
-          index: rule.index,
-          symbolizer: rule.symbolizer
-        };
+  if (frame_offset) {
+      filters.push('ctx["frame-offset"] === ' + frame_offset);
+  }
 
-        if (_if) {
-          r.js = "if(" + _if + "){" + rule.value.toJS(env) + "}";
-        } else {
-          r.js = rule.value.toJS(env);
-        }
+  _.each(this.rules, function (rule) {
+      var exportedRule = {};
 
-        r.constant = rule.value.ev(env).is !== 'field';
-        r.filtered = filtered;
-        shaderAttrs[rule.name].push(r);
-      } else {
-        throw new Error("Ruleset not supported");
+      if (!rule instanceof tree.Rule) {
+          throw new Error("Ruleset not supported");
       }
+
+      exportedRule.index = rule.index;
+      exportedRule.symbolizer = rule.symbolizer;
+      exportedRule.js = "if(" + filters.join(" && ") + "){" + rule.value.toJS(env) + "}";
+      exportedRule.constant = rule.value.ev(env).is !== 'field';
+      exportedRule.filtered = originalFilters !== '';
+
+      shaderAttrs[rule.name] = shaderAttrs[rule.name] || [];
+      shaderAttrs[rule.name].push(exportedRule);
   });
+
   return shaderAttrs;
 };
 

--- a/test/filtered.test.js
+++ b/test/filtered.test.js
@@ -18,49 +18,53 @@
  */
 var assert = require('assert');
 var Carto = require('../lib/carto/index.js');
-var renderer = new Carto.RendererJS({strict: true});
+var renderer = new Carto.RendererJS({ strict: true });
 
 
 describe('Field:filtered propery', function () {
     it('should be false when the property is not filtered', function () {
-        var style = `
-            #layer {
-                marker-fill: red;
-            }`;
+        var style = [
+            '#layer {',
+            '  marker-fill: red;',
+            '}'
+        ].join('\n');
         var layers = renderer.render(style).layers[0].shader;
         assert(!layers['marker-fill'].filtered);
     });
 
     it('should be true when the property is filtered', function () {
-        style = `
-        #layer {
-            [foo > 30]{
-                marker-fill: red;
-            }
-        }`;
+        var style = [
+            '#layer {',
+            '  [foo > 30] {',
+            '    marker-fill: red;',
+            '  }',
+            '}'
+        ].join('\n');
 
         var layers = renderer.render(style).layers[0].shader;
         assert(layers['marker-fill'].filtered);
     });
 
     it('should be true when the property is filtered at first level', function () {
-        style = `
-        #layer [foo > 30]{
-            marker-fill: red;
-        }`;
+        var style = [
+            '#layer [foo > 30] {',
+            '  marker-fill: red;',
+            '}`'
+        ].join('\n');
 
         var layers = renderer.render(style).layers[0].shader;
         assert(layers['marker-fill'].filtered);
     });
 
     it('should be false when the property is not filterd but there is another filtered properties', function () {
-        style = `
-        #layer {
-            marker-fill: red;
-            [bar < 200]{
-                marker-allow-overlap: false;
-            }
-        }`;
+        var style = [
+            '#layer {',
+            '   marker-fill: red;',
+            '   [bar < 200]{',
+            '       marker-allow-overlap: false;',
+            '    }',
+            '}`'
+        ].join('\n');
 
         var layers = renderer.render(style).layers[0].shader;
 
@@ -69,14 +73,14 @@ describe('Field:filtered propery', function () {
     });
 
     it('should be true when the property is filtered and have a default value', function () {
-        style = `
-        #layer {
-            marker-fill: red;
-            [bar < 200]{
-                marker-fill: blue;
-            }
-        }`;
-
+        var style = [
+            '#layer {',
+            '   marker-fill: red;',
+            '   [bar < 200]{',
+            '       marker-fill: blue;',
+            '    }',
+            '}`'
+        ].join('\n');
         var layers = renderer.render(style).layers[0].shader;
 
         assert(layers['marker-fill'].filtered);

--- a/test/filtered.test.js
+++ b/test/filtered.test.js
@@ -1,0 +1,84 @@
+/**
+ * Test the filtered field.
+ * 
+ * When compiled, a rule provides metainformation fields like index, constant...etc
+ * one of this fields is the "filtered field".
+ * 
+ * This field gives information about whether a property is filtered or not.
+ * 
+ * A property is filtered if it was activated inside a filter. In the following cartocss
+ * code marker-color.filtered will be true because is inside a population filter.
+ * 
+ * #layer {
+ *   maker-width: 20;
+ *   [population > 100] {
+ *    marker-color: red; // 
+ *   }
+ * }
+ */
+var assert = require('assert');
+var Carto = require('../lib/carto/index.js');
+var renderer = new Carto.RendererJS({strict: true});
+
+
+describe('Field:filtered propery', function () {
+    it('should be false when the property is not filtered', function () {
+        var style = `
+            #layer {
+                marker-fill: red;
+            }`;
+        var layers = renderer.render(style).layers[0].shader;
+        assert(!layers['marker-fill'].filtered);
+    });
+
+    it('should be true when the property is filtered', function () {
+        style = `
+        #layer {
+            [foo > 30]{
+                marker-fill: red;
+            }
+        }`;
+
+        var layers = renderer.render(style).layers[0].shader;
+        assert(layers['marker-fill'].filtered);
+    });
+
+    it('should be true when the property is filtered at first level', function () {
+        style = `
+        #layer [foo > 30]{
+            marker-fill: red;
+        }`;
+
+        var layers = renderer.render(style).layers[0].shader;
+        assert(layers['marker-fill'].filtered);
+    });
+
+    it('should be false when the property is not filterd but there is another filtered properties', function () {
+        style = `
+        #layer {
+            marker-fill: red;
+            [bar < 200]{
+                marker-allow-overlap: false;
+            }
+        }`;
+
+        var layers = renderer.render(style).layers[0].shader;
+
+        assert(!layers['marker-fill'].filtered);
+        assert(layers['marker-allow-overlap'].filtered);
+    });
+
+    it('should be true when the property is filtered and have a default value', function () {
+        style = `
+        #layer {
+            marker-fill: red;
+            [bar < 200]{
+                marker-fill: blue;
+            }
+        }`;
+
+        var layers = renderer.render(style).layers[0].shader;
+
+        assert(layers['marker-fill'].filtered);
+    });
+});


### PR DESCRIPTION
In order to achieve https://github.com/CartoDB/tangram-carto/issues/58 we need to know when a rule is a "conditional rule" (a rule inside a filter).

This PR exposes the a **filtered** field for every rule pointing when this rule is filtered or not.