### PR TITLE
Cover 'numbers' type, like in line-dasharray

### DIFF
--- a/lib/carto/tree/value.js
+++ b/lib/carto/tree/value.js
@@ -34,6 +34,12 @@ tree.Value.prototype = {
       var v = val.toString();
       if(val.is === "color" || val.is === 'uri' || val.is === 'string' || val.is === 'keyword') {
         v = "'" + v + "'";
+      } else if (Array.isArray(this.value) && this.value.length > 1) {
+        // This covers something like `line-dasharray: 5, 10;`
+        // where the return _value has more than one element.
+        // Without this the generated code will look like:
+        // _value = 5, 10; which will ignore the 10.
+        v = '[' + this.value.join(',') + ']';
       } else if (val.is === 'field') {
         // replace [variable] by ctx['variable']
         v = v.replace(/\[([^\]]*)\]/g, function(matched) {

--- a/test/rendering_js.test.js
+++ b/test/rendering_js.test.js
@@ -195,6 +195,18 @@ describe('RenderingJS', function() {
     assert.equal(width, 8);
   });
 
+  it("should work with numbers", function(){
+    var css = [
+      '#layer {',
+      '  line-dasharray: 5, 10;',
+      '}'
+    ].join('\n');
+    var shader = (new carto.RendererJS({ debug: false })).render(css);
+    var layer = shader.getLayers()[0];
+    var dasharray = layer.shader['line-dasharray'].style({value: 4}, {zoom: 1});
+    assert.deepEqual(dasharray, [5, 10]);
+  });
+
   it("should not throw `ReferenceError` with `=~` operator", function(){
     var css = [
       '#layer[name=~".*wadus*"] {',


### PR DESCRIPTION
This covers something like `line-dasharray: 5, 10;` where the return _value has more than one element. Without this the generated code will look like: _value = 5, 10; which will ignore the 10.