### PR TITLE
adds shield-placement-type to torque-reference

### DIFF
--- a/lib/carto/torque-reference.js
+++ b/lib/carto/torque-reference.js
@@ -838,6 +838,18 @@ var _mapnik_reference_latest = {
                 "default-value": "point",
                 "doc": "How this shield should be placed. Point placement attempts to place it on top of points, line places along lines multiple times per feature, vertex places on the vertexes of polygons, and interior attempts to place inside of polygons."
             },
+            "placement-type": {
+                "css": "shield-placement-type",
+                "doc": "Re-position and/or re-size shield to avoid overlaps. \"simple\" for basic algorithm (using shield-placements string,) \"dummy\" to turn this feature off.",
+                "type": [
+                    "dummy",
+                    "simple",
+                    "list"
+                ],
+                "expression":true,
+                "default-meaning": "Alternative placements will not be enabled.",
+                "default-value": "dummy"
+            },
             "avoid-edges": {
                 "css": "shield-avoid-edges",
                 "doc": "Tell positioning algorithm to avoid labeling near intersection edges.",


### PR DESCRIPTION
re: https://github.com/CartoDB/support/issues/894

- carto: https://github.com/CartoDB/carto/pull/47
- torque: https://github.com/CartoDB/torque/pull/293
- carto.js: https://github.com/CartoDB/cartodb.js/pull/2060
- cartodb: https://github.com/CartoDB/cartodb/pull/13612

![pageshot of untitled map carto 2018-02-04-1839 09](https://user-images.githubusercontent.com/36676/36554487-b36fffd6-17ff-11e8-9838-d28b57fee581.png)
