### PR TITLE
Fixed variable declaration to work on strict environments

### DIFF
--- a/lib/carto/parser.js
+++ b/lib/carto/parser.js
@@ -527,8 +527,8 @@ carto.Parser = function Parser(env) {
                 var a, attachment,
                     e, elements = [],
                     f, filters = new tree.Filterset(),
-                    z, zooms = [],
-                    frame_offset = tree.FrameOffset.none;
+                    z, zooms = [], fo,
+                    frame_offset = tree.FrameOffset.none,
                     segments = 0, conditions = 0;
 
                 while (


### PR DESCRIPTION
I was gettint a "segments" is not defined error because of the way segments was declared without the var prefix.
It looks like it was a bug, the colon after frame_offset declaration had to be a comma.

Also, the fo variable was used but not declared, wich also raised an error on my environment.